### PR TITLE
Might be saver to pass an array to the rollback() method

### DIFF
--- a/src/Console/Commands/RollbackMigrateData.php
+++ b/src/Console/Commands/RollbackMigrateData.php
@@ -65,6 +65,6 @@ class RollbackMigrateData extends Command
 
     protected function getMigrationPath()
     {
-        return $this->laravel->databasePath().DIRECTORY_SEPARATOR.'data-migrations';
+        return [$this->laravel->databasePath().DIRECTORY_SEPARATOR.'data-migrations'];
     }
 }


### PR DESCRIPTION
A refactor in the laravel-framework caused the migrations to fail when the path is a `string` instead of an `array`. See the pull request on github: https://github.com/laravel/framework/pull/18535

As the laravel-framework uses arrays itself, it might be saver to do the same here.

`return [$this->laravel->basePath().'/'.$this->option('path')];`
in
`laravel\framework\src\Illuminate\Database\Console\Migrations\BaseCommand.php`