### PR TITLE
Add support for php 8 and Illuminate 8

### DIFF
--- a/assets/database/migrations/2017_03_09_192353_create_data_migration_table.php
+++ b/assets/database/migrations/2017_03_09_192353_create_data_migration_table.php
@@ -1,8 +1,9 @@
 <?php
 
-use Illuminate\Support\Facades\Schema;
-use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Schema;
 
 class CreateDataMigrationTable extends Migration
 {
@@ -29,7 +30,7 @@ class CreateDataMigrationTable extends Migration
      */
     public function down()
     {
-        if (config('data-migrations.rollback_table')) {
+        if (Config::get('data-migrations.rollback_table')) {
             Schema::dropIfExists('data_migrations');
         }
     }

--- a/composer.json
+++ b/composer.json
@@ -7,8 +7,10 @@
         "email": "hi@michiel.email"
     }],
     "require": {
-        "php": "^7.2",
-        "laravel/framework": "^7.0"
+        "php": "^7.2 || ^8.0",
+        "illuminate/console": "^7.0 || ^8.0",
+        "illuminate/database": "^7.0 || ^8.0",
+        "illuminate/support": "^7.0 || ^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/DataMigrationsServiceProvider.php
+++ b/src/DataMigrationsServiceProvider.php
@@ -3,7 +3,6 @@
 namespace Michielfb\DataMigrations;
 
 use Illuminate\Support\ServiceProvider;
-use Illuminate\Database\Migrations\Migrator;
 use Michielfb\DataMigrations\Console\Commands\MakeDataMigrationCommand;
 use Michielfb\DataMigrations\Console\Commands\MigrateDataCommand;
 use Michielfb\DataMigrations\Console\Commands\RollbackMigrateDataCommand;


### PR DESCRIPTION
Hey there,

this PR contains the following changes:

* change the Laravel Framework dependency to Illuminate packages, to be also compatible to minor Frameworks such as Lumen, without making it necessary to download all Laravel Framework dependencies
* add support for php 8
* add support for Illuminate 8

As this package contains no tests, which is of course hard to achieve, I did a visual check, and it looks fine. 
This change does not necessarily require a new major release (https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api), so I guess version `2.1.0` would be fine, but that’s of course up to the maintainer to decide :)